### PR TITLE
Fixes for config and form validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinpt/agent.websdk",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "description": "Pinpoint Agent WebSDK",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
- Fixed issue where the config which was sent from the integration back to the parent wasn't getting re-rendered in the app context
- Fixed Form to throw an error to handle validation errors and display the error and handle state


NOTE: @pec1985 this will break existing forms because instead of returning an error on Form callback, you need to just throw an Error.  The form will now set an error if you raise an error to the message of the error during validation so we can display the error.

Here's working Github example:


```typescript
const SelfManagedForm = ({ callback }: any) => {
	const form = {
		basic: {
			password: {
				display: 'Personal Access Token',
				help: 'Please enter your Personal Access Token for this user',
			},
		},
	};
	return (
		<Form type={FormType.BASIC} form={form} name="GitHub" callback={async (auth: IAppBasicAuth) => {
			let url = auth.url!;
			const u = new URL(url!);
			if (url?.indexOf('/graphql') < 0) {
				u.pathname = '/graphql';
				auth.url = u.toString();
			}
			const enc = btoa(auth.username + ":" + auth.password);
			const [data, status] = await Graphql.query(auth.url!, `query { viewer { id } }`, undefined, {Authorization: `Basic ${enc}`});
			if (status !== 200) {
				throw new Error(data.message ?? 'Invalid Credentials');
			}
			callback();
		}} />
	);
};
```